### PR TITLE
Only travis test Python 2.7 and 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ notifications:
 language: python
 python:
   - "2.7"
-  - "3.4"
-  - "3.5"
   - "3.6"
 env:
   - DEPS="pip nose future numpy scipy"


### PR DESCRIPTION
This will fix the Travis build errors we're currently getting, which are caused by a dependency not supported on 3.4 and 3.5.